### PR TITLE
feat: accept `username` as an optional parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ import Phoenix from "phoenix-server-js";
 
 const start = async () => {
   const phoenix = new Phoenix({
-    username: "phoenix",
+    username: "phoenix", // optional
     token: "your_api_token_here",
-    host: "http://127.0.0.1:9740",
+    host: "http://127.0.0.1:9740", // optional
   });
 
   // Node Management examples

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ import Phoenix from "phoenix-server-js";
 
 const start = async () => {
   const phoenix = new Phoenix({
+    username: "phoenix",
     token: "your_api_token_here",
     host: "http://127.0.0.1:9740",
   });

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -2,9 +2,9 @@ import Phoenix from "../src/index";
 
 const start = async () => {
   const phoenix = new Phoenix({
-    username: "phoenix",
+    username: "phoenix", // optional
     token: "your_token_goes_here",
-    host: "http://127.0.0.1:9740",
+    host: "http://127.0.0.1:9740", // optional
   });
 
   // Node Management examples

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -2,6 +2,7 @@ import Phoenix from "../src/index";
 
 const start = async () => {
   const phoenix = new Phoenix({
+    username: "phoenix",
     token: "your_token_goes_here",
     host: "http://127.0.0.1:9740",
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   PayInvoiceResponse,
   PaymentInfo,
   PaymentInfoOutgoing,
-  PhoenixConfig
+  PhoenixConfig,
 } from "./types";
 
 class Phoenix {

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,26 +10,28 @@ import {
   PayInvoiceResponse,
   PaymentInfo,
   PaymentInfoOutgoing,
-  PhoenixConfig,
+  PhoenixConfig
 } from "./types";
 
 class Phoenix {
   private _http;
+  private _username;
   private _token;
   private _host;
 
-  constructor({ token, host = "http://127.0.0.1:9740" }: PhoenixConfig) {
+  constructor({ username, token, host }: PhoenixConfig) {
+    this._username = username;
     this._token = token;
     this._host = host;
 
     this._http = axios.create({
-      baseURL: host,
+      baseURL: this._host,
       headers: {
         "Content-Type": "application/x-www-form-urlencoded",
       },
       auth: {
-        username: "phoenix",
-        password: token,
+        username: this._username,
+        password: this._host,
       },
     });
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ class Phoenix {
   private _token;
   private _host;
 
-  constructor({ username, token, host }: PhoenixConfig) {
+  constructor({ token, host ="http://127.0.0.1:9740", username = "phoenix" }: PhoenixConfig) {
     this._username = username;
     this._token = token;
     this._host = host;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,7 @@
 export interface PhoenixConfig {
-  username: string;
   token: string;
-  host: string;
+  host?: string;
+  username?: string;
 }
 
 export interface Channel {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export interface PhoenixConfig {
+  username: string;
   token: string;
-  host?: string;
+  host: string;
 }
 
 export interface Channel {


### PR DESCRIPTION
Looking at the code. It is best if we accept both the username and host. This PR allows the user to pass these parameters. This way, the user can decide to change the username and host for the daemon. What do you think?